### PR TITLE
removed state export

### DIFF
--- a/eventEmitter/index.mjs
+++ b/eventEmitter/index.mjs
@@ -1,6 +1,6 @@
 import eeModule from 'event-emitter'
 
-function eventEmitter ({ee = eeModule} = {}) {
+export default function ({ee = eeModule, state = {}} = {}) {
 
   var events = ee({})
   var noop = () => {}
@@ -10,11 +10,10 @@ function eventEmitter ({ee = eeModule} = {}) {
 
       //Set a break point on the following line to monitor all events being broadcast
       console.log('Event broadcast: ' + eventName)
-      events.emit(eventName, eventObject)
+      events.emit(eventName, eventObject, state)
     }
 
     function on (eventName, cb) {
-
       //Set a break point on the following line to monitor all events being listened to
       events.on(eventName, cb)
     }
@@ -32,10 +31,10 @@ function eventEmitter ({ee = eeModule} = {}) {
     }
 
     return {
-      broadcast: broadcast,
-      on: on,
-      once: once,
-      off: off
+      broadcast,
+      on,
+      once,
+      off
     }
   } else {
     return {
@@ -47,6 +46,3 @@ function eventEmitter ({ee = eeModule} = {}) {
   }
 
 }
-
-export default new eventEmitter()
-export { eventEmitter }

--- a/eventEmitter/test.mjs
+++ b/eventEmitter/test.mjs
@@ -2,7 +2,7 @@ import chai from 'chai'
 import dirtyChai from 'dirty-chai'
 import sinon from 'sinon'
 import sinonChai from 'sinon-chai'
-import { eventEmitter } from './index'
+import eventEmitter from './index'
 import jsdomGlobal from 'jsdom-global'
 
 const {expect} = chai

--- a/halfcab.mjs
+++ b/halfcab.mjs
@@ -9,7 +9,7 @@ import cssInject from 'csjs-inject'
 import merge from 'deepmerge'
 import marked from 'marked'
 import htmlEntities from 'html-entities'
-import geb, { eventEmitter } from './eventEmitter'
+import eventEmitter from './eventEmitter'
 import qs from 'qs'
 import toSource from 'tosource'
 
@@ -66,6 +66,8 @@ if (typeof window !== 'undefined') {
     return output
   }
 }
+
+let geb = new eventEmitter({state})
 
 let html = (strings, ...values) => {
   // fix pelo 0.0.4+ intercepting csjs object
@@ -350,7 +352,7 @@ export default function (config, {shiftyRouter = shiftyRouterModule, href = href
 
     href(location => {
       if(externalRoutes.includes(location.pathname)){
-         window.location = location.pathname
+        window.location = location.pathname
         return
       }
 
@@ -368,16 +370,15 @@ export default function (config, {shiftyRouter = shiftyRouterModule, href = href
 
       let r = document.querySelector(el)
       rootEl = update(r, c)
-      return resolve(rootEl)
+      return resolve({rootEl, state})
     }
     rootEl = c
-    resolve(rootEl)//if no root element provided, just return the root component
+    resolve({rootEl, state})//if no root element provided, just return the root component and the state
   })
 }
 
 let cd = {}//empty object for storing client dependencies (or mocks or them on the server)
 export {
-  state,
   getRouteComponent,
   cache,
   stateUpdated as rerender,

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "halfcab",
-  "version": "8.2.4",
+  "version": "9.0.0",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "halfcab",
-  "version": "8.2.4",
+  "version": "9.0.0",
   "description": "A simple universal JavaScript framework focused on making use of es2015 template strings to build components.",
   "main": "halfcab.mjs",
   "module": "halfcab.mjs",

--- a/test.mjs
+++ b/test.mjs
@@ -54,7 +54,6 @@ describe('halfcab', () => {
         formIsValid,
         emptyBody,
         css,
-        state,
         getRouteComponent
       } = halfcabModule)
       halfcab = halfcabModule.default
@@ -90,14 +89,9 @@ describe('halfcab', () => {
         formIsValid,
         emptyBody,
         css,
-        state,
         getRouteComponent
       } = halfcabModule)
       halfcab = halfcabModule.default
-    })
-
-    it('has initial data with router property to be available', async () => {
-      expect(state.router).to.exist()
     })
 
     it('Produces an HTML element when rendering', () => {
@@ -118,7 +112,6 @@ describe('halfcab', () => {
       return halfcab({
         el: '#root',
         baseName: 'Resorts Interactive',
-        baseApiPath: '/api/webroutes',
         components () {
           return html `<div></div>`
         }
@@ -131,29 +124,36 @@ describe('halfcab', () => {
     it('updating state causes a rerender with state', () => {
       return halfcab({
         baseName: 'Resorts Interactive',
-        baseApiPath: '/api/webroutes',
         components (args) {
           return html`<div>${args.testing || ''}</div>`
         }
       })
-        .then(rootEl => {
+        .then(({rootEl, state}) => {
           updateState({testing: 'works'})
           expect(rootEl.innerHTML.includes('works')).to.be.true()
         })
     })
 
     it('updates state without merging arrays when told to', () => {
-      updateState({
-        myArray: ['1', '2', '3']
+      return halfcab({
+        baseName: 'Resorts Interactive',
+        components () {
+          return html `<div></div>`
+        }
       })
+        .then(({rootEl, state}) => {
+          updateState({
+            myArray: ['1', '2', '3']
+          })
 
-      updateState({
-        myArray: ['4']
-      }, {
-        arrayMerge: false
-      })
+          updateState({
+            myArray: ['4']
+          }, {
+            arrayMerge: false
+          })
+          expect(state.myArray.length).to.equal(1)
+        })
 
-      expect(state.myArray.length).to.equal(1)
     })
 
     it('updating state without deepmerge overwrites objects', () => {
@@ -164,12 +164,11 @@ describe('halfcab', () => {
             `
       return halfcab({
         baseName: 'Resorts Interactive',
-        baseApiPath: '/api/webroutes',
         components (args) {
           return html `<div class="${style.myStyle}">${args.testing.inner || ''}</div>`
         }
       })
-        .then(rootEl => {
+        .then(({rootEl, state}) => {
           updateState({testing: {inner: 'works'}})
           updateState({testing: {inner2: 'works'}}, {
             deepMerge: false
@@ -181,12 +180,11 @@ describe('halfcab', () => {
     it('injects external content without error', () => {
       return halfcab({
         baseName: 'Resorts Interactive',
-        baseApiPath: '/api/webroutes',
         components (args) {
           return html `<div>${injectMarkdown('### Heading')}</div>`
         }
       })
-        .then(rootEl => {
+        .then(({rootEl, state}) => {
           emptyBody()
           expect(rootEl.innerHTML.indexOf('###')).to.equal(-1)
           expect(rootEl.innerHTML.indexOf('<h3')).not.to.equal(-1)
@@ -196,12 +194,11 @@ describe('halfcab', () => {
     it('injects markdown without wrapper without error', () => {
       return halfcab({
         baseName: 'Resorts Interactive',
-        baseApiPath: '/api/webroutes',
         components (args) {
           return html `<div>${injectMarkdown('### Heading', {wrapper: false})}</div>`
         }
       })
-        .then(rootEl => {
+        .then(({rootEl, state}) => {
           emptyBody()
           expect(rootEl.innerHTML.indexOf('###')).to.equal(-1)
           expect(rootEl.innerHTML.indexOf('<h3')).not.to.equal(-1)


### PR DESCRIPTION
- Removed state object from export to encourage top-down components data flow.
- state made available as second argument in geb.on callback, and returned response from halfcab()